### PR TITLE
propagate the model param to the nodejs connection

### DIFF
--- a/dist/lib/client.d.ts
+++ b/dist/lib/client.d.ts
@@ -26,7 +26,7 @@
  * @property {string} [model]
  * @property {string[]} [modalities]
  * @property {string} [instructions]
- * @property {"alloy"|"shimmer"|"echo"} [voice]
+ * @property {"alloy"|"ash"|"ballad"|"coral"|"echo"|"sage"|"shimmer"|"verse"} [voice]
  * @property {AudioFormatType} [input_audio_format]
  * @property {AudioFormatType} [output_audio_format]
  * @property {AudioTranscriptionType|null} [input_audio_transcription]
@@ -337,7 +337,7 @@ export type SessionResourceType = {
     model?: string;
     modalities?: string[];
     instructions?: string;
-    voice?: "alloy" | "shimmer" | "echo";
+    voice?: "alloy"|"ash"|"ballad"|"coral"|"echo"|"sage"|"shimmer"|"verse";
     input_audio_format?: AudioFormatType;
     output_audio_format?: AudioFormatType;
     input_audio_transcription?: AudioTranscriptionType | null;

--- a/lib/api.js
+++ b/lib/api.js
@@ -115,7 +115,7 @@ export class RealtimeAPI extends RealtimeEventHandler {
       const wsModule = await import(/* webpackIgnore: true */ moduleName);
       const WebSocket = wsModule.default;
       const ws = new WebSocket(
-        'wss://api.openai.com/v1/realtime?model=gpt-4o-realtime-preview-2024-10-01',
+        `wss://api.openai.com/v1/realtime?model=${model}`,
         [],
         {
           finishRequest: (request) => {

--- a/lib/client.js
+++ b/lib/client.js
@@ -394,13 +394,14 @@ export class RealtimeClient extends RealtimeEventHandler {
   /**
    * Connects to the Realtime WebSocket API
    * Updates session config and conversation config
+   * @param {{model?: string}} [settings]
    * @returns {Promise<true>}
    */
-  async connect() {
+  async connect({ model } = { model: 'gpt-4o-realtime-preview-2024-10-01' }) {
     if (this.isConnected()) {
       throw new Error(`Already connected, use .disconnect() first`);
     }
-    await this.realtime.connect();
+    await this.realtime.connect({ model });
     this.updateSession();
     return true;
   }

--- a/lib/client.js
+++ b/lib/client.js
@@ -35,7 +35,7 @@ import { RealtimeUtils } from './utils.js';
  * @property {string} [model]
  * @property {string[]} [modalities]
  * @property {string} [instructions]
- * @property {"alloy"|"shimmer"|"echo"} [voice]
+ * @property {"alloy"|"ash"|"ballad"|"coral"|"echo"|"sage"|"shimmer"|"verse"} [voice]
  * @property {AudioFormatType} [input_audio_format]
  * @property {AudioFormatType} [output_audio_format]
  * @property {AudioTranscriptionType|null} [input_audio_transcription]
@@ -202,7 +202,7 @@ export class RealtimeClient extends RealtimeEventHandler {
     this.defaultSessionConfig = {
       modalities: ['text', 'audio'],
       instructions: '',
-      voice: 'alloy',
+      voice: 'verse',
       input_audio_format: 'pcm16',
       output_audio_format: 'pcm16',
       input_audio_transcription: null,


### PR DESCRIPTION
[Jira ticket](https://holidayextras.jira.com/browse/APPS-1623)

Propagate the OpenAI model argument to the NodeJS connect method.
This way within the chat-assistant-gateway we can pass the new model "gpt-4o-realtime-preview-2024-12-17" and use all it's benefits.